### PR TITLE
Add tests for exception formatting and TTY guard logging

### DIFF
--- a/modules/clitt/src/test/test_terminal.py
+++ b/modules/clitt/src/test/test_terminal.py
@@ -16,6 +16,7 @@ from _test_setup import setup_test_environment
 
 setup_test_environment()
 
+from clitt.core.exception.exceptions import NotATerminalError
 from clitt.core.term.screen import Screen
 from clitt.core.term.terminal import Terminal
 from hspylib.modules.application.exit_status import ExitStatus
@@ -24,11 +25,16 @@ from hspylib.modules.application.exit_status import ExitStatus
 class TestTerminalAttributes(unittest.TestCase):
     @patch.object(Terminal, "is_a_tty", return_value=False)
     def test_set_enable_echo_should_guard_when_not_tty(self, mock_is_tty):
-        with patch("clitt.core.term.terminal.os.popen") as mock_popen:
+        with patch("clitt.core.term.terminal.os.popen") as mock_popen, \
+            patch("clitt.core.term.terminal.log.warning") as mock_warning:
             Terminal.set_enable_echo(True)
 
         mock_is_tty.assert_called_once()
         mock_popen.assert_not_called()
+        mock_warning.assert_called_once()
+        warning_arg = mock_warning.call_args.args[0]
+        self.assertIsInstance(warning_arg, NotATerminalError)
+        self.assertIn("set_enable_echo:: Requires a terminal (TTY)", str(warning_arg))
 
     @patch.object(Terminal, "is_a_tty", return_value=True)
     def test_set_enable_echo_should_invoke_stty_when_tty(self, mock_is_tty):
@@ -42,11 +48,16 @@ class TestTerminalAttributes(unittest.TestCase):
 
     @patch.object(Terminal, "is_a_tty", return_value=False)
     def test_set_auto_wrap_should_guard_when_not_tty(self, mock_is_tty):
-        with patch("clitt.core.term.terminal.sysout") as mock_sysout:
+        with patch("clitt.core.term.terminal.sysout") as mock_sysout, \
+            patch("clitt.core.term.terminal.log.warning") as mock_warning:
             Terminal.set_auto_wrap(True)
 
         mock_is_tty.assert_called_once()
         mock_sysout.assert_not_called()
+        mock_warning.assert_called_once()
+        warning_arg = mock_warning.call_args.args[0]
+        self.assertIsInstance(warning_arg, NotATerminalError)
+        self.assertIn("set_auto_wrap:: Requires a terminal (TTY)", str(warning_arg))
 
     @patch.object(Terminal, "is_a_tty", return_value=True)
     def test_set_auto_wrap_should_emit_escape_sequence_when_tty(self, mock_is_tty):
@@ -60,11 +71,16 @@ class TestTerminalAttributes(unittest.TestCase):
 
     @patch.object(Terminal, "is_a_tty", return_value=False)
     def test_set_show_cursor_should_guard_when_not_tty(self, mock_is_tty):
-        with patch("clitt.core.term.terminal.sysout") as mock_sysout:
+        with patch("clitt.core.term.terminal.sysout") as mock_sysout, \
+            patch("clitt.core.term.terminal.log.warning") as mock_warning:
             Terminal.set_show_cursor(True)
 
         mock_is_tty.assert_called_once()
         mock_sysout.assert_not_called()
+        mock_warning.assert_called_once()
+        warning_arg = mock_warning.call_args.args[0]
+        self.assertIsInstance(warning_arg, NotATerminalError)
+        self.assertIn("set_show_cursor:: Requires a terminal (TTY)", str(warning_arg))
 
     @patch.object(Terminal, "is_a_tty", return_value=True)
     def test_set_show_cursor_should_emit_escape_sequence_when_tty(self, mock_is_tty):

--- a/modules/hspylib/src/test/__init__.py
+++ b/modules/hspylib/src/test/__init__.py
@@ -5,10 +5,21 @@
 # Package: test
 """Package initialization."""
 
+from pathlib import Path
+import sys
+
+_TEST_PACKAGE = Path(__file__).resolve().parent
+_SRC_ROOT = _TEST_PACKAGE.parent
+_MAIN_SRC = _SRC_ROOT / "main"
+
+for path in (_SRC_ROOT, _MAIN_SRC):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
 __all__ = [
-    'core', 
-    'mock', 
-    'modules', 
+    'core',
+    'mock',
+    'modules',
     'shared'
 ]
 __version__ = '1.12.54'

--- a/modules/hspylib/src/test/core/exception/test_exceptions.py
+++ b/modules/hspylib/src/test/core/exception/test_exceptions.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+   @project: HsPyLib
+   test.core.exception
+      @file: test_exceptions.py
+   @created: Fri, 10 May 2024
+   @license: MIT - Please refer to <https://opensource.org/licenses/MIT>
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+TEST_ROOT = Path(__file__).resolve().parents[3]
+if str(TEST_ROOT) not in sys.path:
+    sys.path.insert(0, str(TEST_ROOT))
+SRC_MAIN = TEST_ROOT / "main"
+if str(SRC_MAIN) not in sys.path:
+    sys.path.insert(0, str(SRC_MAIN))
+
+from hspylib.core.exception.exceptions import (
+    ApplicationError,
+    HSBaseException,
+    InvalidArgumentError,
+    InvalidInputError,
+    InvalidJsonMapping,
+    InvalidMapping,
+    InvalidOptionError,
+    InvalidStateError,
+    KeyboardInputError,
+    PropertyError,
+    WidgetExecutionError,
+    WidgetNotFoundError,
+)
+
+
+class TestHsBaseException(unittest.TestCase):
+    def test_should_format_message_with_cause_and_context(self) -> None:
+        with patch("hspylib.core.exception.exceptions.log.error") as mock_log:
+            try:
+                raise ValueError("bad value")
+            except ValueError as err:
+                exc = HSBaseException("Something happened", err)
+
+        message = str(exc)
+        self.assertTrue(message.startswith("### Something happened :bad value:"))
+        self.assertRegex(message, r"\(File .*test_exceptions.py, Line ")
+        mock_log.assert_called_once_with(message)
+
+    def test_should_preserve_message_when_no_active_exception(self) -> None:
+        with patch("hspylib.core.exception.exceptions.log.error") as mock_log:
+            exc = HSBaseException("Just a message")
+
+        self.assertEqual("Just a message", str(exc))
+        mock_log.assert_called_once_with("Just a message")
+
+    def test_custom_exceptions_should_preserve_hierarchy(self) -> None:
+        expected_subclasses = [
+            ApplicationError,
+            PropertyError,
+            KeyboardInputError,
+            InvalidOptionError,
+            WidgetExecutionError,
+            WidgetNotFoundError,
+            InvalidMapping,
+            InvalidJsonMapping,
+        ]
+        for subclass in expected_subclasses:
+            with self.subTest(subclass=subclass.__name__):
+                self.assertTrue(issubclass(subclass, HSBaseException))
+
+        direct_exceptions = [InvalidInputError, InvalidArgumentError, InvalidStateError]
+        for exc_type in direct_exceptions:
+            with self.subTest(exc_type=exc_type.__name__):
+                self.assertTrue(issubclass(exc_type, Exception))
+                self.assertFalse(issubclass(exc_type, HSBaseException))
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestHsBaseException)
+    unittest.TextTestRunner(verbosity=2, failfast=True).run(suite)


### PR DESCRIPTION
## Summary
- add unit tests covering HSBaseException message formatting and exception hierarchy
- ensure Terminal TTY guard paths log NotATerminalError instances when triggered
- update test package initialization to include source directories on the Python path

## Testing
- python modules/hspylib/src/test/core/exception/test_exceptions.py
- python modules/clitt/src/test/test_terminal.py

------
https://chatgpt.com/codex/tasks/task_e_6908039ba53883269c391b55c64c269e